### PR TITLE
geom_alt props

### DIFF
--- a/data/421/173/253/421173253.geojson
+++ b/data/421/173/253/421173253.geojson
@@ -143,6 +143,9 @@
     },
     "wof:country":"JO",
     "wof:created":1459008976,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"c917b91dc77c8c499de09bf4bf65b1af",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":421173253,
-    "wof:lastmodified":1566724725,
+    "wof:lastmodified":1582317878,
     "wof:name":"Maan Community College",
     "wof:parent_id":85672637,
     "wof:placetype":"locality",

--- a/data/421/200/421/421200421.geojson
+++ b/data/421/200/421/421200421.geojson
@@ -651,6 +651,9 @@
     },
     "wof:country":"JO",
     "wof:created":1459010022,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"86b4f3c1aa6d3d6cbc944dd8319dc6a2",
     "wof:hierarchy":[
         {
@@ -661,7 +664,7 @@
         }
     ],
     "wof:id":421200421,
-    "wof:lastmodified":1566724727,
+    "wof:lastmodified":1582317878,
     "wof:name":"Amman",
     "wof:parent_id":85672627,
     "wof:placetype":"locality",

--- a/data/856/324/25/85632425.geojson
+++ b/data/856/324/25/85632425.geojson
@@ -955,7 +955,6 @@
     "src:geom":"whosonfirst",
     "src:geom_alt":[
         "quattroshapes",
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1029,7 +1028,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1582317877,
+    "wof:lastmodified":1583204438,
     "wof:name":"Jordan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/324/25/85632425.geojson
+++ b/data/856/324/25/85632425.geojson
@@ -954,8 +954,9 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"whosonfirst",
     "src:geom_alt":[
+        "quattroshapes",
         "naturalearth",
-        "quattroshapes"
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
@@ -1009,6 +1010,11 @@
     },
     "wof:country":"JO",
     "wof:country_alpha3":"JOR",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"4c0d4125d058fbb499d015a6ce22a376",
     "wof:hierarchy":[
         {
@@ -1023,7 +1029,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566724699,
+    "wof:lastmodified":1582317877,
     "wof:name":"Jordan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/859/031/49/85903149.geojson
+++ b/data/859/031/49/85903149.geojson
@@ -76,6 +76,10 @@
         "qs_pg:id":1120158
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2669d3a289afcf094b0c1f5c28d38f5e",
     "wof:hierarchy":[
         {
@@ -90,7 +94,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724698,
+    "wof:lastmodified":1582317875,
     "wof:name":"\u0627\u0644\u0634\u0645\u064a\u0633\u0627\u0646\u064a",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/043/05/85904305.geojson
+++ b/data/859/043/05/85904305.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":329382
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"92ec3b66ff69ac6faea77d36ced8a8a3",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724698,
+    "wof:lastmodified":1582317876,
     "wof:name":"Jabal Al-ashrafiyyeh",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/043/09/85904309.geojson
+++ b/data/859/043/09/85904309.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":908790
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"0711816e308544a830109b8d146ecd8d",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724698,
+    "wof:lastmodified":1582317876,
     "wof:name":"Al Abdaliyeh",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/063/49/85906349.geojson
+++ b/data/859/063/49/85906349.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1179491
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"263190ce49218b1172541ef4e1234f80",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724698,
+    "wof:lastmodified":1582317876,
     "wof:name":"Royal Palaces",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/063/51/85906351.geojson
+++ b/data/859/063/51/85906351.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":945629
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"121359b193c689d360c18140524aec5c",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724698,
+    "wof:lastmodified":1582317876,
     "wof:name":"Al-muhajireen",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/063/53/85906353.geojson
+++ b/data/859/063/53/85906353.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":346106
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"9ae43c404410ba29f255d334f8bd1be3",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724698,
+    "wof:lastmodified":1582317876,
     "wof:name":"Amman City Centre",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/063/55/85906355.geojson
+++ b/data/859/063/55/85906355.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1298578
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a007a2916e8f897d758bc8e94207b9b9",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724698,
+    "wof:lastmodified":1582317876,
     "wof:name":"Al-hussein Al Sharqi",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/79/85906779.geojson
+++ b/data/859/067/79/85906779.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":484996
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a088a66e21fd829bbd75d4d90e6f8dec",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724699,
+    "wof:lastmodified":1582317876,
     "wof:name":"Hay Al Madina Ar Riyadiyya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/81/85906781.geojson
+++ b/data/859/067/81/85906781.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":366721
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"edad4ac696eca32ea6e04d9c51b64510",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724699,
+    "wof:lastmodified":1582317876,
     "wof:name":"Hay As Salam",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/83/85906783.geojson
+++ b/data/859/067/83/85906783.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":897003
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7283d94d9e7f916c68ccc4c6494a5a96",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724699,
+    "wof:lastmodified":1582317876,
     "wof:name":"Umm Udhayna",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/85/85906785.geojson
+++ b/data/859/067/85/85906785.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":366720
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f90251a6e6062377e241df8bbbd81571",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724699,
+    "wof:lastmodified":1582317876,
     "wof:name":"Bayadir Wadi As Sir",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/87/85906787.geojson
+++ b/data/859/067/87/85906787.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":897004
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"627d82692d439c662493c690dccc5334",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724699,
+    "wof:lastmodified":1582317876,
     "wof:name":"As Suwayfiyya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/89/85906789.geojson
+++ b/data/859/067/89/85906789.geojson
@@ -81,6 +81,10 @@
         "qs_pg:id":1063575
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7f0dd47548c374fa002fc80607445b68",
     "wof:hierarchy":[
         {
@@ -95,7 +99,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724699,
+    "wof:lastmodified":1582317876,
     "wof:name":"Abdali",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/93/85906793.geojson
+++ b/data/859/067/93/85906793.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":268829
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"034bc333cb232f756ce93521a8b91fa5",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724699,
+    "wof:lastmodified":1582317876,
     "wof:name":"\u062c\u0628\u0644 \u0627\u0644\u062d\u0633\u064a\u0646",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/95/85906795.geojson
+++ b/data/859/067/95/85906795.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":366729
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e84d9fbd89f41b5a78367de0fba8cc3f",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724699,
+    "wof:lastmodified":1582317876,
     "wof:name":"\u062c\u0628\u0644 \u0627\u0644\u0642\u0644\u0639\u0629",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/97/85906797.geojson
+++ b/data/859/067/97/85906797.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":366730
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"6cfbee2c80f7a3055fd876a9ac2ae65e",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724699,
+    "wof:lastmodified":1582317876,
     "wof:name":"Jabal Al Ashrafiyya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/067/99/85906799.geojson
+++ b/data/859/067/99/85906799.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":366727
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"111b3a86a823fd9e5d7778c07a3f7283",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724699,
+    "wof:lastmodified":1582317876,
     "wof:name":"Jabal An Nadhif",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/068/01/85906801.geojson
+++ b/data/859/068/01/85906801.geojson
@@ -155,6 +155,10 @@
         "wk:page":"Al Quwaysimah"
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"8a7685cf44cafe814a6536ebcfe60479",
     "wof:hierarchy":[
         {
@@ -169,7 +173,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724698,
+    "wof:lastmodified":1582317876,
     "wof:name":"Al Quwaysima",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/068/03/85906803.geojson
+++ b/data/859/068/03/85906803.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":507704
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"bbd2b22e052cfa9cd1d6bef71619d194",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724698,
+    "wof:lastmodified":1582317876,
     "wof:name":"Jabal Al Hadid",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/068/05/85906805.geojson
+++ b/data/859/068/05/85906805.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":507705
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"bf1128362df2c82ed52361adc20a0ddf",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724698,
+    "wof:lastmodified":1582317876,
     "wof:name":"Jabal Ar Rawda",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/068/07/85906807.geojson
+++ b/data/859/068/07/85906807.geojson
@@ -105,6 +105,10 @@
         "wk:page":"Al-Mogableen"
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5a2df8ef7fdbc2b8d99dd2fcdf30dce6",
     "wof:hierarchy":[
         {
@@ -119,7 +123,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724698,
+    "wof:lastmodified":1582317876,
     "wof:name":"Al Muqabilayn",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/068/11/85906811.geojson
+++ b/data/859/068/11/85906811.geojson
@@ -79,6 +79,10 @@
         "qs_pg:id":990000
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2393b94c393efcb8600399c5f20e1501",
     "wof:hierarchy":[
         {
@@ -93,7 +97,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724698,
+    "wof:lastmodified":1582317876,
     "wof:name":"\u0627\u0644\u0647\u0644\u0627\u0644",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/068/13/85906813.geojson
+++ b/data/859/068/13/85906813.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1184296
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a224a495763162f99251244ac67d7b2a",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724698,
+    "wof:lastmodified":1582317876,
     "wof:name":"Ra's Al 'ayn",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/068/15/85906815.geojson
+++ b/data/859/068/15/85906815.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1184297
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"6e9cf719372664fd2b344c76828b904d",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724698,
+    "wof:lastmodified":1582317876,
     "wof:name":"Wadi 'abdun",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/068/17/85906817.geojson
+++ b/data/859/068/17/85906817.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1262787
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"3dafea3f5735847f00829dfc13238d46",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724698,
+    "wof:lastmodified":1582317876,
     "wof:name":"Hay Zahran",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/068/19/85906819.geojson
+++ b/data/859/068/19/85906819.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1087541
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"35fed66dcca88aa3a333ee3538d6e61d",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724698,
+    "wof:lastmodified":1582317876,
     "wof:name":"Ar Radwan",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/068/21/85906821.geojson
+++ b/data/859/068/21/85906821.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1087548
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"dfe6cdd5d640836705a835ca47038709",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724698,
+    "wof:lastmodified":1582317876,
     "wof:name":"Jabal Al Luwaybida",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/068/23/85906823.geojson
+++ b/data/859/068/23/85906823.geojson
@@ -192,6 +192,10 @@
         "wd:id":"Q475247"
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"01e0aae90d2173821628037f5061b081",
     "wof:hierarchy":[
         {
@@ -206,7 +210,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724698,
+    "wof:lastmodified":1582317876,
     "wof:name":"Al Muhajirin",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/068/25/85906825.geojson
+++ b/data/859/068/25/85906825.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":241560
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e45657c778fa47799d6a29a7cfc5cc72",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724699,
+    "wof:lastmodified":1582317876,
     "wof:name":"Marka Al Janubiyya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/068/29/85906829.geojson
+++ b/data/859/068/29/85906829.geojson
@@ -69,6 +69,10 @@
         "qs_pg:id":1180010
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c875886c6b02dbadb32fc6d4d984f7f0",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724698,
+    "wof:lastmodified":1582317876,
     "wof:name":"Marka Ash Shamaliyya",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/068/31/85906831.geojson
+++ b/data/859/068/31/85906831.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":1180011
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"e2b316f56a5f1e8c5e171545282eb731",
     "wof:hierarchy":[
         {
@@ -85,7 +89,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724698,
+    "wof:lastmodified":1582317876,
     "wof:name":"Sport City",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/859/068/33/85906833.geojson
+++ b/data/859/068/33/85906833.geojson
@@ -142,6 +142,10 @@
         "qs_pg:id":1101379
     },
     "wof:country":"JO",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b2b09eb5e7c4182646cfbedbfc2f09bd",
     "wof:hierarchy":[
         {
@@ -156,7 +160,7 @@
     "wof:lang":[
         "ara"
     ],
-    "wof:lastmodified":1566724698,
+    "wof:lastmodified":1582317876,
     "wof:name":"Qatna",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.