### PR TITLE
Update non-ascii names, store existing localized names

### DIFF
--- a/data/421/166/615/421166615.geojson
+++ b/data/421/166/615/421166615.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0645 \u062c\u0648\u0632\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Umm Juza"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421166615,
-    "wof:lastmodified":1566724722,
-    "wof:name":"\u0627\u0645 \u062c\u0648\u0632\u0629",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Umm Juza",
     "wof:parent_id":85672653,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/166/615/421166615.geojson
+++ b/data/421/166/615/421166615.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421166615,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423094,
     "wof:name":"Umm Juza",
     "wof:parent_id":85672653,
     "wof:placetype":"locality",

--- a/data/421/169/569/421169569.geojson
+++ b/data/421/169/569/421169569.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421169569,
-    "wof:lastmodified":1601068396,
+    "wof:lastmodified":1601423088,
     "wof:name":"Dabouq",
     "wof:parent_id":85672627,
     "wof:placetype":"locality",

--- a/data/421/169/569/421169569.geojson
+++ b/data/421/169/569/421169569.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u062f\u0627\u0628\u0648\u0642"
+    ],
+    "name:eng_x_preferred":[
+        "Dabouq"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421169569,
-    "wof:lastmodified":1566724724,
-    "wof:name":"\u062f\u0627\u0628\u0648\u0642",
+    "wof:lastmodified":1601068396,
+    "wof:name":"Dabouq",
     "wof:parent_id":85672627,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/173/917/421173917.geojson
+++ b/data/421/173/917/421173917.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421173917,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Swemeh",
     "wof:parent_id":85672653,
     "wof:placetype":"locality",

--- a/data/421/173/917/421173917.geojson
+++ b/data/421/173/917/421173917.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0633\u0648\u064a\u0645\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Swemeh"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421173917,
-    "wof:lastmodified":1566724725,
-    "wof:name":"\u0633\u0648\u064a\u0645\u0629",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Swemeh",
     "wof:parent_id":85672653,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/175/039/421175039.geojson
+++ b/data/421/175/039/421175039.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0628\u062a\u0631\u0627\u0621"
+    ],
+    "name:eng_x_preferred":[
+        "Petra"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421175039,
-    "wof:lastmodified":1566724726,
-    "wof:name":"\u0627\u0644\u0628\u062a\u0631\u0627\u0621",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Petra",
     "wof:parent_id":85672637,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/175/039/421175039.geojson
+++ b/data/421/175/039/421175039.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421175039,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423091,
     "wof:name":"Petra",
     "wof:parent_id":85672637,
     "wof:placetype":"locality",

--- a/data/421/176/963/421176963.geojson
+++ b/data/421/176/963/421176963.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0631\u0648\u064a\u0634\u062f"
+    ],
+    "name:eng_x_preferred":[
+        "Al Ruwaished"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421176963,
-    "wof:lastmodified":1566724729,
-    "wof:name":"\u0627\u0644\u0631\u0648\u064a\u0634\u062f",
+    "wof:lastmodified":1601068390,
+    "wof:name":"Al Ruwaished",
     "wof:parent_id":85672623,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/176/963/421176963.geojson
+++ b/data/421/176/963/421176963.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421176963,
-    "wof:lastmodified":1601068390,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Ruwaished",
     "wof:parent_id":85672623,
     "wof:placetype":"locality",

--- a/data/421/177/231/421177231.geojson
+++ b/data/421/177/231/421177231.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421177231,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Shoubak",
     "wof:parent_id":85672637,
     "wof:placetype":"locality",

--- a/data/421/177/231/421177231.geojson
+++ b/data/421/177/231/421177231.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0634\u0648\u0628\u0643"
+    ],
+    "name:eng_x_preferred":[
+        "Al Shoubak"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421177231,
-    "wof:lastmodified":1566724729,
-    "wof:name":"\u0627\u0644\u0634\u0648\u0628\u0643",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Shoubak",
     "wof:parent_id":85672637,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/178/147/421178147.geojson
+++ b/data/421/178/147/421178147.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0639\u062c\u0644\u0648\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Ajloun"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421178147,
-    "wof:lastmodified":1566724729,
-    "wof:name":"\u0639\u062c\u0644\u0648\u0646",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Ajloun",
     "wof:parent_id":85672643,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/178/147/421178147.geojson
+++ b/data/421/178/147/421178147.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421178147,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423083,
     "wof:name":"Ajloun",
     "wof:parent_id":85672643,
     "wof:placetype":"locality",

--- a/data/421/181/971/421181971.geojson
+++ b/data/421/181/971/421181971.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421181971,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Hashmi Al Janobi",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/181/971/421181971.geojson
+++ b/data/421/181/971/421181971.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0647\u0627\u0634\u0645\u064a \u0627\u0644\u062c\u0646\u0648\u0628\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Al Hashmi Al Janobi"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421181971,
-    "wof:lastmodified":1566724726,
-    "wof:name":"\u0627\u0644\u0647\u0627\u0634\u0645\u064a \u0627\u0644\u062c\u0646\u0648\u0628\u064a",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Al Hashmi Al Janobi",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/184/427/421184427.geojson
+++ b/data/421/184/427/421184427.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421184427,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423094,
     "wof:name":"Umm Al Amad",
     "wof:parent_id":85672627,
     "wof:placetype":"locality",

--- a/data/421/184/427/421184427.geojson
+++ b/data/421/184/427/421184427.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0645 \u0627\u0644\u0639\u0645\u062f"
+    ],
+    "name:eng_x_preferred":[
+        "Umm Al Amad"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421184427,
-    "wof:lastmodified":1566724728,
-    "wof:name":"\u0627\u0645 \u0627\u0644\u0639\u0645\u062f",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Umm Al Amad",
     "wof:parent_id":85672627,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/185/121/421185121.geojson
+++ b/data/421/185/121/421185121.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421185121,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Yarout",
     "wof:parent_id":85672661,
     "wof:placetype":"locality",

--- a/data/421/185/121/421185121.geojson
+++ b/data/421/185/121/421185121.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u064a\u0627\u0631\u0648\u062a"
+    ],
+    "name:eng_x_preferred":[
+        "Al Yarout"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421185121,
-    "wof:lastmodified":1566724730,
-    "wof:name":"\u0627\u0644\u064a\u0627\u0631\u0648\u062a",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Al Yarout",
     "wof:parent_id":85672661,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/185/155/421185155.geojson
+++ b/data/421/185/155/421185155.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0628\u0631\u0632\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Barza"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421185155,
-    "wof:lastmodified":1566724730,
-    "wof:name":"\u0628\u0631\u0632\u0627",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Barza",
     "wof:parent_id":85672659,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/185/155/421185155.geojson
+++ b/data/421/185/155/421185155.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421185155,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423087,
     "wof:name":"Barza",
     "wof:parent_id":85672659,
     "wof:placetype":"locality",

--- a/data/421/189/985/421189985.geojson
+++ b/data/421/189/985/421189985.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0645\u0627\u062f\u0628\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Madaba"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421189985,
-    "wof:lastmodified":1566724725,
-    "wof:name":"\u0645\u0627\u062f\u0628\u0627",
+    "wof:lastmodified":1601068399,
+    "wof:name":"Madaba",
     "wof:parent_id":85672659,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/189/985/421189985.geojson
+++ b/data/421/189/985/421189985.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421189985,
-    "wof:lastmodified":1601068399,
+    "wof:lastmodified":1601423090,
     "wof:name":"Madaba",
     "wof:parent_id":85672659,
     "wof:placetype":"locality",

--- a/data/421/190/691/421190691.geojson
+++ b/data/421/190/691/421190691.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062c\u0628\u064a\u0647\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Jubeiha"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190691,
-    "wof:lastmodified":1566724727,
-    "wof:name":"\u0627\u0644\u062c\u0628\u064a\u0647\u0629",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Jubeiha",
     "wof:parent_id":85672653,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/190/691/421190691.geojson
+++ b/data/421/190/691/421190691.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190691,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Jubeiha",
     "wof:parent_id":85672653,
     "wof:placetype":"locality",

--- a/data/421/190/693/421190693.geojson
+++ b/data/421/190/693/421190693.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190693,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Karak",
     "wof:parent_id":85672661,
     "wof:placetype":"locality",

--- a/data/421/190/693/421190693.geojson
+++ b/data/421/190/693/421190693.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0643\u0631\u0643"
+    ],
+    "name:eng_x_preferred":[
+        "Al Karak"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190693,
-    "wof:lastmodified":1566724726,
-    "wof:name":"\u0627\u0644\u0643\u0631\u0643",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Karak",
     "wof:parent_id":85672661,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/190/695/421190695.geojson
+++ b/data/421/190/695/421190695.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190695,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Mafraq",
     "wof:parent_id":85672623,
     "wof:placetype":"locality",

--- a/data/421/190/695/421190695.geojson
+++ b/data/421/190/695/421190695.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0641\u0631\u0642"
+    ],
+    "name:eng_x_preferred":[
+        "Al Mafraq"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190695,
-    "wof:lastmodified":1566724726,
-    "wof:name":"\u0627\u0644\u0645\u0641\u0631\u0642",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Mafraq",
     "wof:parent_id":85672623,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/190/699/421190699.geojson
+++ b/data/421/190/699/421190699.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0642\u0627\u0639"
+    ],
+    "name:eng_x_preferred":[
+        "Al Qaa"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190699,
-    "wof:lastmodified":1566724727,
-    "wof:name":"\u0627\u0644\u0642\u0627\u0639",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Qaa",
     "wof:parent_id":85672637,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/190/699/421190699.geojson
+++ b/data/421/190/699/421190699.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190699,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Qaa",
     "wof:parent_id":85672637,
     "wof:placetype":"locality",

--- a/data/421/190/701/421190701.geojson
+++ b/data/421/190/701/421190701.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190701,
-    "wof:lastmodified":1601068389,
+    "wof:lastmodified":1601423084,
     "wof:name":"Al Jada'a",
     "wof:parent_id":85672661,
     "wof:placetype":"locality",

--- a/data/421/190/701/421190701.geojson
+++ b/data/421/190/701/421190701.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u062c\u062f\u0639\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Al Jada'a"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190701,
-    "wof:lastmodified":1566724726,
-    "wof:name":"\u0627\u0644\u062c\u062f\u0639\u0627",
+    "wof:lastmodified":1601068389,
+    "wof:name":"Al Jada'a",
     "wof:parent_id":85672661,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/190/705/421190705.geojson
+++ b/data/421/190/705/421190705.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190705,
-    "wof:lastmodified":1601068394,
+    "wof:lastmodified":1601423087,
     "wof:name":"Aydoun",
     "wof:parent_id":85672641,
     "wof:placetype":"locality",

--- a/data/421/190/705/421190705.geojson
+++ b/data/421/190/705/421190705.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u064a\u062f\u0648\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Aydoun"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190705,
-    "wof:lastmodified":1566724727,
-    "wof:name":"\u0627\u064a\u062f\u0648\u0646",
+    "wof:lastmodified":1601068394,
+    "wof:name":"Aydoun",
     "wof:parent_id":85672641,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/190/717/421190717.geojson
+++ b/data/421/190/717/421190717.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0633\u0648\u0641"
+    ],
+    "name:eng_x_preferred":[
+        "Souf"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421190717,
-    "wof:lastmodified":1566724727,
-    "wof:name":"\u0633\u0648\u0641",
+    "wof:lastmodified":1601068397,
+    "wof:name":"Souf",
     "wof:parent_id":85672643,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/190/717/421190717.geojson
+++ b/data/421/190/717/421190717.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421190717,
-    "wof:lastmodified":1601068397,
+    "wof:lastmodified":1601423092,
     "wof:name":"Souf",
     "wof:parent_id":85672643,
     "wof:placetype":"locality",

--- a/data/421/193/301/421193301.geojson
+++ b/data/421/193/301/421193301.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421193301,
-    "wof:lastmodified":1601068388,
+    "wof:lastmodified":1601423087,
     "wof:name":"Ariha",
     "wof:parent_id":85672659,
     "wof:placetype":"locality",

--- a/data/421/193/301/421193301.geojson
+++ b/data/421/193/301/421193301.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0631\u064a\u062d\u0627"
+    ],
+    "name:eng_x_preferred":[
+        "Ariha"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421193301,
-    "wof:lastmodified":1566724723,
-    "wof:name":"\u0627\u0631\u064a\u062d\u0627",
+    "wof:lastmodified":1601068388,
+    "wof:name":"Ariha",
     "wof:parent_id":85672659,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/193/623/421193623.geojson
+++ b/data/421/193/623/421193623.geojson
@@ -16,6 +16,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":15.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0639\u0628\u062f\u0644\u064a"
+    ],
+    "name:eng_x_preferred":[
+        "Al Abdali"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421193623,
-    "wof:lastmodified":1566724723,
-    "wof:name":"\u0627\u0644\u0639\u0628\u062f\u0644\u064a",
+    "wof:lastmodified":1601068391,
+    "wof:name":"Al Abdali",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/193/623/421193623.geojson
+++ b/data/421/193/623/421193623.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421193623,
-    "wof:lastmodified":1601068391,
+    "wof:lastmodified":1601423083,
     "wof:name":"Al Abdali",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/421/199/997/421199997.geojson
+++ b/data/421/199/997/421199997.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421199997,
-    "wof:lastmodified":1601068392,
+    "wof:lastmodified":1601423085,
     "wof:name":"Al Muqabalayn",
     "wof:parent_id":85672627,
     "wof:placetype":"locality",

--- a/data/421/199/997/421199997.geojson
+++ b/data/421/199/997/421199997.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u0645\u0642\u0627\u0628\u0644\u064a\u0646"
+    ],
+    "name:eng_x_preferred":[
+        "Al Muqabalayn"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421199997,
-    "wof:lastmodified":1566724727,
-    "wof:name":"\u0627\u0644\u0645\u0642\u0627\u0628\u0644\u064a\u0646",
+    "wof:lastmodified":1601068392,
+    "wof:name":"Al Muqabalayn",
     "wof:parent_id":85672627,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/202/381/421202381.geojson
+++ b/data/421/202/381/421202381.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421202381,
-    "wof:lastmodified":1601068393,
+    "wof:lastmodified":1601423086,
     "wof:name":"Al Yadudah",
     "wof:parent_id":85672627,
     "wof:placetype":"locality",

--- a/data/421/202/381/421202381.geojson
+++ b/data/421/202/381/421202381.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0627\u0644\u064a\u0627\u062f\u0648\u062f\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Al Yadudah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421202381,
-    "wof:lastmodified":1566724724,
-    "wof:name":"\u0627\u0644\u064a\u0627\u062f\u0648\u062f\u0629",
+    "wof:lastmodified":1601068393,
+    "wof:name":"Al Yadudah",
     "wof:parent_id":85672627,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",

--- a/data/421/202/383/421202383.geojson
+++ b/data/421/202/383/421202383.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":421202383,
-    "wof:lastmodified":1601068398,
+    "wof:lastmodified":1601423086,
     "wof:name":"Anjarah",
     "wof:parent_id":85672643,
     "wof:placetype":"locality",

--- a/data/421/202/383/421202383.geojson
+++ b/data/421/202/383/421202383.geojson
@@ -17,6 +17,12 @@
     "mz:is_current":-1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0639\u0646\u062c\u0631\u0629"
+    ],
+    "name:eng_x_preferred":[
+        "Anjarah"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -58,8 +64,8 @@
         }
     ],
     "wof:id":421202383,
-    "wof:lastmodified":1566724724,
-    "wof:name":"\u0639\u0646\u062c\u0631\u0629",
+    "wof:lastmodified":1601068398,
+    "wof:name":"Anjarah",
     "wof:parent_id":85672643,
     "wof:placetype":"locality",
     "wof:repo":"whosonfirst-data-admin-jo",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/183.

This PR updates loclized `wof:name` values in records that currently have no `name:eng_x_*` properties. There are other records that will need to be updated as part of this work too, but those will be handled in a separate PR.

The existing `wof:name` should be stored in the appropriate `name:*` property, with `wof:name` and `name:eng_x_preferred` properties getting updated English name values.

No PIP work needed, these are just property updates.