### PR TITLE
Update megacity records

### DIFF
--- a/data/421/200/421/421200421.geojson
+++ b/data/421/200/421/421200421.geojson
@@ -647,6 +647,7 @@
     "wof:concordances":{
         "gn:id":250441,
         "gp:id":1968902,
+        "ne:id":1159150807,
         "qs_pg:id":1304303,
         "wd:id":"Q3805",
         "wk:page":"Amman"
@@ -666,7 +667,8 @@
         }
     ],
     "wof:id":421200421,
-    "wof:lastmodified":1607390900,
+    "wof:lastmodified":1608688177,
+    "wof:megacity":1,
     "wof:name":"Amman",
     "wof:parent_id":85672627,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1547

- Updates megacity records with new:
  - concordances
  - names (if not already present)
  - label centroids
  - megacity flags
- Updates geometries of any megacity record with a `Point` geometry
- Updates parent geometries when necessary