### PR TITLE
jo concordances, placetype local, and more

### DIFF
--- a/data/856/324/25/85632425.geojson
+++ b/data/856/324/25/85632425.geojson
@@ -1199,6 +1199,7 @@
         "hasc:id":"JO",
         "icao:code":"JY",
         "ioc:id":"JOR",
+        "iso:code":"JO",
         "itu:id":"JOR",
         "loc:id":"n79072819",
         "m49:code":"400",
@@ -1213,6 +1214,7 @@
         "wk:page":"Jordan",
         "wmo:id":"JD"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JO",
     "wof:country_alpha3":"JOR",
     "wof:geom_alt":[
@@ -1235,7 +1237,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694639594,
+    "wof:lastmodified":1695881255,
     "wof:name":"Jordan",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/726/19/85672619.geojson
+++ b/data/856/726/19/85672619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.605773,
-    "geom:area_square_m":6499947520.786703,
+    "geom:area_square_m":6499948720.812863,
     "geom:bbox":"34.949385,29.231731,35.740251,30.719967",
     "geom:latitude":29.79738,
     "geom:longitude":35.319845,
@@ -303,12 +303,14 @@
         "gn:id":443122,
         "gp:id":20070290,
         "hasc:id":"JO.AQ",
+        "iso:code":"JO-AQ",
         "iso:id":"JO-AQ",
         "qs_pg:id":1285773,
         "wd:id":"Q260796"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JO",
-    "wof:geomhash":"03992c544c70d2f28c241d68b2a7c155",
+    "wof:geomhash":"d6ec8c464d692f01a60916c63dd4c4b0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -323,7 +325,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690937486,
+    "wof:lastmodified":1695884329,
     "wof:name":"Aqaba",
     "wof:parent_id":85632425,
     "wof:placetype":"region",

--- a/data/856/726/23/85672623.geojson
+++ b/data/856/726/23/85672623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.562345,
-    "geom:area_square_m":26759232475.7066,
+    "geom:area_square_m":26759227588.537148,
     "geom:bbox":"35.947243,31.69612,39.291999,33.371685",
     "geom:latitude":32.377273,
     "geom:longitude":37.920624,
@@ -297,12 +297,14 @@
         "gn:id":250583,
         "gp:id":2345930,
         "hasc:id":"JO.MA",
+        "iso:code":"JO-MA",
         "iso:id":"JO-MA",
         "qs_pg:id":891832,
         "wd:id":"Q854871"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JO",
-    "wof:geomhash":"edb1946ace2b6b6316411bfe94d1d688",
+    "wof:geomhash":"12c222abc5c137ff7ad39ce17be58bdb",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -317,7 +319,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690937487,
+    "wof:lastmodified":1695884329,
     "wof:name":"Mafraq",
     "wof:parent_id":85632425,
     "wof:placetype":"region",

--- a/data/856/726/27/85672627.geojson
+++ b/data/856/726/27/85672627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.747894,
-    "geom:area_square_m":7878233415.149699,
+    "geom:area_square_m":7878229360.361568,
     "geom:bbox":"35.661731,31.247292,37.221722,32.045848",
     "geom:latitude":31.578283,
     "geom:longitude":36.342815,
@@ -325,13 +325,15 @@
         "gn:id":250439,
         "gp:id":20070289,
         "hasc:id":"JO.AM",
+        "iso:code":"JO-AM",
         "iso:id":"JO-AM",
         "qs_pg:id":1285775,
         "unlc:id":"JO-AM",
         "wd:id":"Q472788"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JO",
-    "wof:geomhash":"acbf0533c711e2d87230815fb28102ba",
+    "wof:geomhash":"2ff02017ae681e4dc5a552d8f949ac74",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -346,7 +348,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690937486,
+    "wof:lastmodified":1695884405,
     "wof:name":"Amman",
     "wof:parent_id":85632425,
     "wof:placetype":"region",

--- a/data/856/726/33/85672633.geojson
+++ b/data/856/726/33/85672633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.205508,
-    "geom:area_square_m":2183234786.090581,
+    "geom:area_square_m":2183235042.071985,
     "geom:bbox":"35.263882,30.603274,36.023776,30.998418",
     "geom:latitude":30.778533,
     "geom:longitude":35.627642,
@@ -326,13 +326,15 @@
         "gn:id":250199,
         "gp:id":2345932,
         "hasc:id":"JO.AT",
+        "iso:code":"JO-AT",
         "iso:id":"JO-AT",
         "qs_pg:id":891833,
         "unlc:id":"JO-AT",
         "wd:id":"Q750259"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JO",
-    "wof:geomhash":"7d3f07dc9ea37882ff12db9bddf4a1ab",
+    "wof:geomhash":"c78f9241b6fa78fa37dd96729b96b0d0",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -347,7 +349,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690937486,
+    "wof:lastmodified":1695884329,
     "wof:name":"Tafilah",
     "wof:parent_id":85632425,
     "wof:placetype":"region",

--- a/data/856/726/37/85672637.geojson
+++ b/data/856/726/37/85672637.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.084963,
-    "geom:area_square_m":32919771598.854301,
+    "geom:area_square_m":32919769980.793869,
     "geom:bbox":"35.299117,29.189951,37.981381,31.248636",
     "geom:latitude":30.342571,
     "geom:longitude":36.53875,
@@ -317,13 +317,15 @@
         "gn:id":248380,
         "gp:id":2345928,
         "hasc:id":"JO.MN",
+        "iso:code":"JO-MN",
         "iso:id":"JO-MN",
         "qs_pg:id":1135118,
         "unlc:id":"JO-MN",
         "wd:id":"Q606340"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JO",
-    "wof:geomhash":"b7cf9d00838a1aa784314121e109b763",
+    "wof:geomhash":"61ca26d76ea6303268f14f5b2562b61c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -338,7 +340,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690937487,
+    "wof:lastmodified":1695884329,
     "wof:name":"Ma`an",
     "wof:parent_id":85632425,
     "wof:placetype":"region",

--- a/data/856/726/41/85672641.geojson
+++ b/data/856/726/41/85672641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.172618,
-    "geom:area_square_m":1799918887.973503,
+    "geom:area_square_m":1799918700.95721,
     "geom:bbox":"35.545148,32.183824,36.094211,32.748054",
     "geom:latitude":32.512559,
     "geom:longitude":35.790969,
@@ -317,13 +317,15 @@
         "gn:id":248944,
         "gp:id":20070291,
         "hasc:id":"JO.IR",
+        "iso:code":"JO-IR",
         "iso:id":"JO-IR",
         "qs_pg:id":1285776,
         "unlc:id":"JO-IR",
         "wd:id":"Q721441"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JO",
-    "wof:geomhash":"3d3c44df439b760766bb3fe494961eb0",
+    "wof:geomhash":"3004d98520a2aa1a1068ef68afd5b4a2",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -338,7 +340,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690937487,
+    "wof:lastmodified":1695884405,
     "wof:name":"Irbid",
     "wof:parent_id":85632425,
     "wof:placetype":"region",

--- a/data/856/726/43/85672643.geojson
+++ b/data/856/726/43/85672643.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039621,
-    "geom:area_square_m":414175125.587005,
+    "geom:area_square_m":414175302.925819,
     "geom:bbox":"35.61672,32.156177,35.905333,32.402002",
     "geom:latitude":32.287053,
     "geom:longitude":35.73798,
@@ -351,13 +351,15 @@
         "gn:id":443120,
         "gp:id":20070293,
         "hasc:id":"JO.AJ",
+        "iso:code":"JO-AJ",
         "iso:id":"JO-AJ",
         "qs_pg:id":890123,
         "unlc:id":"JO-AJ",
         "wd:id":"Q506658"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JO",
-    "wof:geomhash":"a7193872751784df5d2ad24f2d6127d9",
+    "wof:geomhash":"992b8860199624a1098383ac13f2ca7c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -372,7 +374,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690937486,
+    "wof:lastmodified":1695884329,
     "wof:name":"Ajlun",
     "wof:parent_id":85632425,
     "wof:placetype":"region",

--- a/data/856/726/49/85672649.geojson
+++ b/data/856/726/49/85672649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039225,
-    "geom:area_square_m":410322886.524964,
+    "geom:area_square_m":410322601.581242,
     "geom:bbox":"35.694804,32.095664,36.017213,32.354744",
     "geom:latitude":32.22161,
     "geom:longitude":35.879312,
@@ -298,13 +298,15 @@
         "gn:id":443121,
         "gp:id":20070292,
         "hasc:id":"JO.JA",
+        "iso:code":"JO-JA",
         "iso:id":"JO-JA",
         "qs_pg:id":890121,
         "unlc:id":"JO-JA",
         "wd:id":"Q750270"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JO",
-    "wof:geomhash":"37ec5f10f313e45029b9d80c5704dad7",
+    "wof:geomhash":"4ca4d1e284e26d33e6bca3edbecb9d78",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -319,7 +321,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690937488,
+    "wof:lastmodified":1695884329,
     "wof:name":"Jarash",
     "wof:parent_id":85632425,
     "wof:placetype":"region",

--- a/data/856/726/53/85672653.geojson
+++ b/data/856/726/53/85672653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.108808,
-    "geom:area_square_m":1141280591.36832,
+    "geom:area_square_m":1141281148.391181,
     "geom:bbox":"35.502479,31.680806,35.941197,32.190929",
     "geom:latitude":31.976358,
     "geom:longitude":35.667794,
@@ -300,12 +300,14 @@
         "gn:id":250751,
         "gp:id":2345927,
         "hasc:id":"JO.BA",
+        "iso:code":"JO-BA",
         "iso:id":"JO-BA",
         "qs_pg:id":1135119,
         "wd:id":"Q721431"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JO",
-    "wof:geomhash":"359a9ec055a9fa7e9094f11b8408edcf",
+    "wof:geomhash":"0d0d979b33eda4362f99e26a5a46e545",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -320,7 +322,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690937487,
+    "wof:lastmodified":1695884329,
     "wof:name":"Balqa",
     "wof:parent_id":85632425,
     "wof:placetype":"region",

--- a/data/856/726/59/85672659.geojson
+++ b/data/856/726/59/85672659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.120014,
-    "geom:area_square_m":1264282654.047751,
+    "geom:area_square_m":1264283522.271575,
     "geom:bbox":"35.457128,31.40382,35.887505,31.790825",
     "geom:latitude":31.576103,
     "geom:longitude":35.675462,
@@ -301,13 +301,15 @@
         "gn:id":443123,
         "gp:id":20070288,
         "hasc:id":"JO.MD",
+        "iso:code":"JO-MD",
         "iso:id":"JO-MD",
         "qs_pg:id":246023,
         "unlc:id":"JO-MD",
         "wd:id":"Q750447"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JO",
-    "wof:geomhash":"9b8ea0f02f26775ff61fedb2e4dab6d1",
+    "wof:geomhash":"72305177d861f85882da07a9adcfe6c9",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -322,7 +324,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690937485,
+    "wof:lastmodified":1695884330,
     "wof:name":"Madaba",
     "wof:parent_id":85632425,
     "wof:placetype":"region",

--- a/data/856/726/61/85672661.geojson
+++ b/data/856/726/61/85672661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.328644,
-    "geom:area_square_m":3478659593.676939,
+    "geom:area_square_m":3478659106.790761,
     "geom:bbox":"35.34711,30.767063,36.191931,31.438469",
     "geom:latitude":31.128102,
     "geom:longitude":35.771989,
@@ -306,13 +306,15 @@
         "gn:id":250625,
         "gp:id":2345929,
         "hasc:id":"JO.KA",
+        "iso:code":"JO-KA",
         "iso:id":"JO-KA",
         "qs_pg:id":894903,
         "wd:id":"Q735245",
         "wk:page":"Karak Governorate"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JO",
-    "wof:geomhash":"0a2386a3b95a8ff0bde246e71128a903",
+    "wof:geomhash":"67bd39b556b68afe85c72401bccb7fda",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -327,7 +329,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690937485,
+    "wof:lastmodified":1695884330,
     "wof:name":"Karak",
     "wof:parent_id":85632425,
     "wof:placetype":"region",

--- a/data/856/726/67/85672667.geojson
+++ b/data/856/726/67/85672667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.399653,
-    "geom:area_square_m":4197438151.575256,
+    "geom:area_square_m":4197444183.17366,
     "geom:bbox":"35.895876,31.500814,37.761412,32.196666",
     "geom:latitude":31.824908,
     "geom:longitude":36.844282,
@@ -305,13 +305,15 @@
         "gn:id":250092,
         "gp:id":2345933,
         "hasc:id":"JO.AZ",
+        "iso:code":"JO-AZ",
         "iso:id":"JO-AZ",
         "qs_pg:id":430972,
         "unlc:id":"JO-AZ",
         "wd:id":"Q721445"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"JO",
-    "wof:geomhash":"694929f44e0eda557078e89dbc3d6bf1",
+    "wof:geomhash":"277149758c75a5014d0aba53bcd1c549",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -326,7 +328,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1690937485,
+    "wof:lastmodified":1695884330,
     "wof:name":"Zarqa",
     "wof:parent_id":85632425,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.